### PR TITLE
Fix importing config file

### DIFF
--- a/packages/hypertest-plugin-playwright/src/index.ts
+++ b/packages/hypertest-plugin-playwright/src/index.ts
@@ -66,7 +66,6 @@ const PlaywrightRunnerPlugin = (options: {
       const { config: pwConfig } = await getPlaywrightConfig(
         options.config.logger,
       );
-      console.log('pwConfig: ', pwConfig);
       const projectName = getProjectName(pwConfig);
       const testDir = getTestDir(pwConfig);
       options.config.logger.verbose(`Playwright tests directory: ${testDir}`);


### PR DESCRIPTION
`//file` path standard is neccessary to make it work on Windows