### PR TITLE
disable Docker buildx provenance attestations for AWS Lambda image

### DIFF
--- a/packages/hypertest-plugin-playwright/src/docker-build.ts
+++ b/packages/hypertest-plugin-playwright/src/docker-build.ts
@@ -31,7 +31,10 @@ export async function buildDockerImage<
   env = {},
 }: DockerBuildOptions<TDockerfile>): Promise<void> {
   const args = [
+    'buildx',
     'build',
+    '--provenance=false',
+    '--load',
     ['-f', '-'],
     platform ? ['--platform', platform] : [],
     imageTag ? ['-t', imageTag] : [],


### PR DESCRIPTION
Change build to buildx.
Remove problematic metadata for AWS Lambda

`--provenance=false`
AWS Lambda does not support OCI provenance attestations (metadata).
Disabling this ensures compatibility with Lambda's container runtime 
and avoids InvalidParameterValueException.

`--load`
When using buildx, the image is kept in the build cache by default.
--load is required to export it to the local Docker daemon (e.g., for docker push).