### PR TITLE
AWS Lambda doesn't support SBOM attestations

### DIFF
--- a/packages/hypertest-plugin-playwright/src/docker-build.ts
+++ b/packages/hypertest-plugin-playwright/src/docker-build.ts
@@ -34,6 +34,7 @@ export async function buildDockerImage<
     'buildx',
     'build',
     '--provenance=false',
+    '--sbom=false',
     '--load',
     ['-f', '-'],
     platform ? ['--platform', platform] : [],


### PR DESCRIPTION
Follow up to this PR: https://github.com/hypertest-cloud/hypertest/pull/102#pullrequestreview-3684386075