### PR TITLE
104 plugin playwright grep string are broken on windows os

### DIFF
--- a/packages/hypertest-plugin-playwright/src/getGrepString.ts
+++ b/packages/hypertest-plugin-playwright/src/getGrepString.ts
@@ -6,8 +6,11 @@ const getRelativeUnixPath = (from: string, to: string): string => {
 };
 
 const escapeForTerminalRegex = (value: string): string => {
+  // First, escape regex special characters
   const regexSafe = escapeStringRegexp(value);
 
+  // Double the backslashes for shell escaping since the grep pattern
+  // is passed inside double quotes in the shell command
   return regexSafe.replace(/\\/g, '\\\\');
 };
 


### PR DESCRIPTION
Building grep was not OS agnostic. So when plugin was creating grep path in windows we didn't get unix path. 