### PR TITLE
118 core tests directory hashing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Note: `hypertest-types` must build first (see workspace ordering in root `packag
 Two plugin interfaces in `hypertest-types`:
 
 **TestRunnerPlugin** (`test-runner-plugin.ts`):
-- `getInvokePayloads(runId)`: Returns invoke payloads (one per test file)
+- `getInvokePayloadContext()`: Returns invoke payload context (one per test file)
 - `buildImage()`: Builds Docker image with tests
 
 **CloudProviderPlugin** (`cloud-provider.ts`):

--- a/packages/hypertest-core/src/hashDirectory.ts
+++ b/packages/hypertest-core/src/hashDirectory.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const getTestFiles = async (dirPath: string): Promise<string[]> => {
+  const dirents = await fs.readdir(dirPath, { withFileTypes: true });
+
+  const files = await Promise.all(
+    dirents.map((dirent): Promise<string[]> | string | null => {
+      const res = path.resolve(dirPath, dirent.name);
+
+      if (dirent.isDirectory()) {
+        return getTestFiles(res);
+      }
+
+      return res.endsWith('.spec.ts') ? res : null;
+    }),
+  );
+
+  return files.flat().filter((file): file is string => Boolean(file));
+};
+
+export const hashDirectory = async (dirPath: string) => {
+  const hash = crypto.createHash('sha256');
+
+  try {
+    const allFiles = await getTestFiles(dirPath);
+    const relativeFiles = allFiles
+      .map((file) => path.relative(dirPath, file))
+      .sort();
+
+    for (const relPath of relativeFiles) {
+      const absPath = path.join(dirPath, relPath);
+      const fileBuffer = await fs.readFile(absPath);
+
+      const normalizedContent = fileBuffer
+        .toString('utf8')
+        .replace(/\r\n/g, '\n');
+
+      hash.update(relPath);
+      hash.update(normalizedContent);
+    }
+
+    return hash.digest('hex');
+  } catch (err) {
+    if (err instanceof Error) {
+      throw new Error(`Failed on directory hashing: ${err.message}`);
+    }
+
+    throw new Error('Failed on directory hashing');
+  }
+};

--- a/packages/hypertest-core/src/hashDirectory.ts
+++ b/packages/hypertest-core/src/hashDirectory.ts
@@ -2,7 +2,15 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import crypto from 'node:crypto';
 
-const getTestFiles = async (dirPath: string): Promise<string[]> => {
+/**
+ * Recursively gets files from a directory based on allowed extensions.
+ * @param dirPath - The starting directory
+ * @param extensions - Array of suffixes to match (e.g., ['.spec.ts', '.test.ts'])
+ */
+const getTestFiles = async (
+  dirPath: string,
+  extensions?: string[], // Default value if none provided
+): Promise<string[]> => {
   const dirents = await fs.readdir(dirPath, { withFileTypes: true });
 
   const files = await Promise.all(
@@ -10,21 +18,24 @@ const getTestFiles = async (dirPath: string): Promise<string[]> => {
       const res = path.resolve(dirPath, dirent.name);
 
       if (dirent.isDirectory()) {
-        return getTestFiles(res);
+        return getTestFiles(res, extensions);
       }
 
-      return res.endsWith('.spec.ts') ? res : null;
+      const isMatch =
+        !extensions || extensions.some((ext) => res.endsWith(ext));
+
+      return isMatch ? res : null;
     }),
   );
 
   return files.flat().filter((file): file is string => Boolean(file));
 };
 
-export const hashDirectory = async (dirPath: string) => {
+export const hashDirectory = async (dirPath: string, extensions?: string[]) => {
   const hash = crypto.createHash('sha256');
 
   try {
-    const allFiles = await getTestFiles(dirPath);
+    const allFiles = await getTestFiles(dirPath, extensions);
     const relativeFiles = allFiles
       .map((file) => path.relative(dirPath, file))
       .sort();

--- a/packages/hypertest-core/src/hashDirectory.ts
+++ b/packages/hypertest-core/src/hashDirectory.ts
@@ -36,6 +36,12 @@ export const hashDirectory = async (dirPath: string, extensions?: string[]) => {
 
   try {
     const allFiles = await getTestFiles(dirPath, extensions);
+    if (!allFiles.length) {
+      throw new Error(
+        `Directory is empty or no files match the extensions in: ${dirPath}`,
+      );
+    }
+
     const relativeFiles = allFiles
       .map((file) => path.relative(dirPath, file))
       .sort();

--- a/packages/hypertest-core/src/hashDirectory.ts
+++ b/packages/hypertest-core/src/hashDirectory.ts
@@ -48,8 +48,8 @@ export const hashDirectory = async (dirPath: string, extensions?: string[]) => {
         .toString('utf8')
         .replace(/\r\n/g, '\n');
 
-      hash.update(relPath);
-      hash.update(normalizedContent);
+      hash.update(`${relPath}\0`);
+      hash.update(`${normalizedContent}\0`);
     }
 
     return hash.digest('hex');

--- a/packages/hypertest-core/src/hashDirectory.ts
+++ b/packages/hypertest-core/src/hashDirectory.ts
@@ -9,7 +9,7 @@ import crypto from 'node:crypto';
  */
 const getTestFiles = async (
   dirPath: string,
-  extensions?: string[], // Default value if none provided
+  extensions?: string[],
 ): Promise<string[]> => {
   const dirents = await fs.readdir(dirPath, { withFileTypes: true });
 

--- a/packages/hypertest-core/src/index.ts
+++ b/packages/hypertest-core/src/index.ts
@@ -39,7 +39,7 @@ export const HypertestCore = <InvokePayloadContext>(options: {
   cloudProvider: CloudProviderPlugin<InvokePayloadContext>;
 }): HypertestCore => {
   const getTestDirHash = async () =>
-    hashDirectory(await options.testRunner.getTestDir());
+    hashDirectory(await options.testRunner.getTestDir(), ['.spec.ts']);
 
   return {
     invoke: async () => {

--- a/packages/hypertest-core/src/index.ts
+++ b/packages/hypertest-core/src/index.ts
@@ -7,6 +7,7 @@ import type {
 } from '@hypertest/hypertest-types';
 import { loadConfig } from './config.js';
 import { promiseMap } from './utils.js';
+import { hashDirectory } from './hashDirectory.js';
 
 interface HypertestCore {
   deploy: () => Promise<void>;
@@ -37,9 +38,8 @@ export const HypertestCore = <InvokePayloadContext>(options: {
   testRunner: TestRunnerPlugin<InvokePayloadContext>;
   cloudProvider: CloudProviderPlugin<InvokePayloadContext>;
 }): HypertestCore => {
-  const getTestDirHash = () => {
-    return 'TODO This needs to be implemented in separated PR';
-  };
+  const getTestDirHash = async () =>
+    hashDirectory(await options.testRunner.getTestDir());
 
   return {
     invoke: async () => {
@@ -47,10 +47,10 @@ export const HypertestCore = <InvokePayloadContext>(options: {
 
       const runId = crypto.randomUUID();
       const manifest = await options.cloudProvider.pullManifest();
-      const testDirHash = getTestDirHash();
+      const testDirHash = await getTestDirHash();
 
       if (manifest.testDirHash !== testDirHash) {
-        options.config.logger.warning(
+        options.config.logger.warn(
           'Your local test code differ from what is deploying in cloud infrastructure',
         );
       }
@@ -99,13 +99,15 @@ export const HypertestCore = <InvokePayloadContext>(options: {
       options.config.logger.info('Building and storing manifest');
       const invokePayloadContext =
         await options.testRunner.getInvokePayloadContext();
-      const testDirHash = getTestDirHash();
+      const testDirHash = await getTestDirHash();
       await options.cloudProvider.updateManifest(
         invokePayloadContext,
         testDirHash,
       );
 
-      options.config.logger.info('Updating lambda image and waiting for deployment to complete');
+      options.config.logger.info(
+        'Updating lambda image and waiting for deployment to complete',
+      );
       await options.cloudProvider.updateLambdaImage();
 
       options.config.logger.info('Deploy successful');

--- a/packages/hypertest-core/src/index.ts
+++ b/packages/hypertest-core/src/index.ts
@@ -50,9 +50,19 @@ export const HypertestCore = <InvokePayloadContext>(options: {
       const testDirHash = await getTestDirHash();
 
       if (manifest.testDirHash !== testDirHash) {
-        options.config.logger.warn(
-          'Your local test code differ from what is deploying in cloud infrastructure',
-        );
+        const message =
+          'Your local test code differ from what is deploying in cloud infrastructure';
+
+        const policyActions = {
+          warning: () => options.config.logger.warn(message),
+          error: () => {
+            throw new Error(message);
+          },
+          // biome-ignore lint/suspicious/noEmptyBlockStatements: <explanation>
+          salience: () => {},
+        };
+
+        policyActions[options.config.driftDetectionPolicy]();
       }
 
       const functionInvokePayloads = manifest.invokePayloadContexts.map(

--- a/packages/hypertest-core/src/index.ts
+++ b/packages/hypertest-core/src/index.ts
@@ -39,7 +39,7 @@ export const HypertestCore = <InvokePayloadContext>(options: {
   cloudProvider: CloudProviderPlugin<InvokePayloadContext>;
 }): HypertestCore => {
   const getTestDirHash = async () =>
-    hashDirectory(await options.testRunner.getTestDir(), ['.spec.ts']);
+    hashDirectory(await options.testRunner.getTestDir());
 
   return {
     invoke: async () => {

--- a/packages/hypertest-core/src/index.ts
+++ b/packages/hypertest-core/src/index.ts
@@ -59,7 +59,7 @@ export const HypertestCore = <InvokePayloadContext>(options: {
             throw new Error(message);
           },
           // biome-ignore lint/suspicious/noEmptyBlockStatements: <explanation>
-          salience: () => {},
+          silence: () => {},
         };
 
         policyActions[options.config.driftDetectionPolicy]();

--- a/packages/hypertest-docs/docs/developers/manifest.md
+++ b/packages/hypertest-docs/docs/developers/manifest.md
@@ -24,9 +24,9 @@ To guarantee that the execution context matches the deployed code, the manifest 
 ### Handling Inconsistencies
 
 The system's response can be configured in the event that the application detects an inconsistency (e.g., a mismatch between the local test directory hash and the manifest's deployed hash). Developers are able to configure the application to do one of the following in the event of a mismatch:
-* **silence** - Remain silent, ignore the mismatch.
-* **warning** - Display a warning, notify the user, but continue
-* **error** - Terminate operation, stop the execution by throwing an error
+* `silence` - Remain silent, ignore the mismatch,
+* `warning` - Display a warning, notify the user, but continue,
+* `error` - Throw an error and stop execution.
 
 ## Configuration and Naming
 

--- a/packages/hypertest-docs/docs/developers/manifest.md
+++ b/packages/hypertest-docs/docs/developers/manifest.md
@@ -40,7 +40,7 @@ The name of the generated manifest file is customizable via the `buildManifestFi
 ```json
 {
   "imageDigest": "sha256:77fe3a37721a5d5bd20d0cafe6946c5980201a8975b70dfba56a83d4e488e13b",
-  "testDirHash": "TODO Update with real example",
+  "testDirHash": "74811828510f638d62d67d9bca795862010f05b52ef0e8ec9623c9697b318f26",
   "invokePayloadContexts": [
     {
       "grep": "^chromium foo/playwright\\\\x2dweb\\\\.spec\\\\.ts get started link$"

--- a/packages/hypertest-docs/docs/developers/manifest.md
+++ b/packages/hypertest-docs/docs/developers/manifest.md
@@ -21,12 +21,12 @@ To guarantee that the execution context matches the deployed code, the manifest 
 * **Image Digest Comparison:** When attempting to use the manifest (via the `invoke` method), the application compares the image digest recorded in the manifest with the image digest of the currently deployed cloud function.
 * **Validation Flow:** Using the directory hash and the image digest, the application flow checks whether current local changes and the deployment target are consistent with what has been pushed to the cloud (i.e., the exact code that is scheduled to be run).
 
-### Handling Inconsistencies (TODO)
+### Handling Inconsistencies
 
-*Future Feature:* We are implementing a configurable response system for when the application detects an inconsistency (e.g., a mismatch between the local test directory hash and the manifest's deployed hash, or differing image digests). Once implemented, developers will be able to configure the application to do one of the following in the event of a mismatch:
-* **Remain silent** (ignore the mismatch)
-* **Issue a warning** (alert the user but continue)
-* **Terminate operation** (block execution to prevent errors)
+The system's response can be configured in the event that the application detects an inconsistency (e.g., a mismatch between the local test directory hash and the manifest's deployed hash). Developers are able to configure the application to do one of the following in the event of a mismatch:
+* **silence** - Remain silent, ignore the mismatch.
+* **warning** - Display a warning, notify the user, but continue
+* **error** - Terminate operation, stop the execution by throwing an error
 
 ## Configuration and Naming
 

--- a/packages/hypertest-docs/docs/getting-started/configuration.md
+++ b/packages/hypertest-docs/docs/getting-started/configuration.md
@@ -33,7 +33,7 @@ export default defineConfig({
   // Custom hypertest build manifest filename
   buildManifestFileName: 'hypertest.manifest.json',
 
-  // TODO After code review (warning | error | salience)
+  // TODO After code review (warning | error | silence)
   driftDetectionPolicy: 'warning',
 
   // Test runner plugin configuration

--- a/packages/hypertest-docs/docs/getting-started/configuration.md
+++ b/packages/hypertest-docs/docs/getting-started/configuration.md
@@ -33,7 +33,7 @@ export default defineConfig({
   // Custom hypertest build manifest filename
   buildManifestFileName: 'hypertest.manifest.json',
 
-  // TODO After code review (warning | error | silence)
+  // Specifies the follow-up actions to be taken if data drift are detected between the deployed manifest and the local test suite. Can be: warning, error or silence
   driftDetectionPolicy: 'warning',
 
   // Test runner plugin configuration

--- a/packages/hypertest-docs/docs/getting-started/configuration.md
+++ b/packages/hypertest-docs/docs/getting-started/configuration.md
@@ -33,6 +33,9 @@ export default defineConfig({
   // Custom hypertest build manifest filename
   buildManifestFileName: 'hypertest.manifest.json',
 
+  // TODO After code review (warning | error | salience)
+  driftDetectionPolicy: 'warning',
+
   // Test runner plugin configuration
   testRunner: playwright({}),
 

--- a/packages/hypertest-docs/docs/getting-started/configuration.md
+++ b/packages/hypertest-docs/docs/getting-started/configuration.md
@@ -33,7 +33,7 @@ export default defineConfig({
   // Custom hypertest build manifest filename
   buildManifestFileName: 'hypertest.manifest.json',
 
-  // Specifies the follow-up actions to be taken if data drift are detected between the deployed manifest and the local test suite. Can be: silence, warning or error
+  // Specifies the action to take if drift is detected between the deployed manifest and the local test suite. Can be: 'silence', 'warning', or 'error'. Defaults to 'warning'.
   driftDetectionPolicy: 'warning',
 
   // Test runner plugin configuration

--- a/packages/hypertest-docs/docs/getting-started/configuration.md
+++ b/packages/hypertest-docs/docs/getting-started/configuration.md
@@ -33,7 +33,7 @@ export default defineConfig({
   // Custom hypertest build manifest filename
   buildManifestFileName: 'hypertest.manifest.json',
 
-  // Specifies the follow-up actions to be taken if data drift are detected between the deployed manifest and the local test suite. Can be: warning, error or silence
+  // Specifies the follow-up actions to be taken if data drift are detected between the deployed manifest and the local test suite. Can be: silence, warning or error
   driftDetectionPolicy: 'warning',
 
   // Test runner plugin configuration

--- a/packages/hypertest-playground/hypertest.config.js
+++ b/packages/hypertest-playground/hypertest.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
   imageName: 'hypertest/playground-playwright',
   localImageName: 'hypertest/playground-playwright',
   localBaseImageName: 'hypertest/local-base-playwright',
+  driftDetectionPolicy: 'warning',
   testRunner: playwright({}),
   loggerOptions: {
     level: 'verbose',

--- a/packages/hypertest-plugin-playwright/src/index.ts
+++ b/packages/hypertest-plugin-playwright/src/index.ts
@@ -121,6 +121,13 @@ const PlaywrightRunnerPlugin = (options: {
 
       return fileContexts.flat();
     },
+    getTestDir: async () => {
+      const { config: pwConfig } = await getPlaywrightConfig(
+        options.config.logger,
+      );
+
+      return getTestDir(pwConfig);
+    },
   };
 };
 

--- a/packages/hypertest-plugin-playwright/src/index.ts
+++ b/packages/hypertest-plugin-playwright/src/index.ts
@@ -18,22 +18,30 @@ import type {
   PlaywrightPluginOptions,
 } from './types.js';
 
-const getPlaywrightConfig = async (
+const CONFIG_FILE_PATH = './playwright.config.js';
+
+const getPlaywrightConfigFactory = (
   logger: winston.Logger,
-): Promise<{
-  playwrightConfigFilepath: string;
-  config: PlaywrightTestConfig;
-}> => {
-  const configFilepath = './playwright.config.js';
-  logger.verbose(`Loading PW config from: ${configFilepath}`);
+): (() => Promise<PlaywrightTestConfig>) => {
+  let pwConfig: PlaywrightTestConfig | null = null;
 
-  const fileUrl = pathToFileURL(
-    path.resolve(process.cwd(), configFilepath),
-  ).href;
+  return async () => {
+    if (pwConfig) {
+      return pwConfig;
+    }
 
-  return {
-    playwrightConfigFilepath: configFilepath,
-    config: await import(fileUrl).then((mod) => mod.default),
+    logger.verbose(`Loading PW config from: ${CONFIG_FILE_PATH}`);
+    const fileUrl = pathToFileURL(
+      path.resolve(process.cwd(), CONFIG_FILE_PATH),
+    ).href;
+
+    pwConfig = await import(fileUrl).then((mod) => mod.default);
+
+    if (pwConfig) {
+      return pwConfig;
+    }
+
+    throw new Error(`Failed to load config from: ${CONFIG_FILE_PATH}`);
   };
 };
 
@@ -61,10 +69,11 @@ const PlaywrightRunnerPlugin = (options: {
   config: ResolvedHypertestConfig;
   dryRun?: boolean;
 }): TestRunnerPlugin<PlaywrightCloudFunctionContext> => {
+  const getPlaywrightConfig = getPlaywrightConfigFactory(options.config.logger);
+
   return {
     buildImage: async () => {
-      const { config: pwConfig, playwrightConfigFilepath } =
-        await getPlaywrightConfig(options.config.logger);
+      const pwConfig = await getPlaywrightConfig();
       const testDir = getTestDir(pwConfig);
       const { localImageName, localBaseImageName } = options.config;
 
@@ -80,7 +89,7 @@ const PlaywrightRunnerPlugin = (options: {
             // biome-ignore lint/style/useNamingConvention: <explanation>
             TEST_DIR: testDir,
             // biome-ignore lint/style/useNamingConvention: <explanation>
-            PLAYWRIGHT_CONFIG_FILEPATH: playwrightConfigFilepath,
+            PLAYWRIGHT_CONFIG_FILEPATH: CONFIG_FILE_PATH,
           },
           env: {},
         });
@@ -92,9 +101,7 @@ const PlaywrightRunnerPlugin = (options: {
       }
     },
     getInvokePayloadContext: async () => {
-      const { config: pwConfig } = await getPlaywrightConfig(
-        options.config.logger,
-      );
+      const pwConfig = await getPlaywrightConfig();
       const projectName = getProjectName(pwConfig);
       const testDir = getTestDir(pwConfig);
       options.config.logger.verbose(`Playwright tests directory: ${testDir}`);
@@ -122,9 +129,7 @@ const PlaywrightRunnerPlugin = (options: {
       return fileContexts.flat();
     },
     getTestDir: async () => {
-      const { config: pwConfig } = await getPlaywrightConfig(
-        options.config.logger,
-      );
+      const pwConfig = await getPlaywrightConfig();
 
       return getTestDir(pwConfig);
     },

--- a/packages/hypertest-provider-cloud-aws/src/index.ts
+++ b/packages/hypertest-provider-cloud-aws/src/index.ts
@@ -409,8 +409,8 @@ const plugin = (
   handler: (config) => {
     return HypertestProviderCloudAWS(
       {
-        ...options,
         lambdaUpdateMaxWaitTime: 600,
+        ...options,
       },
       config,
     );

--- a/packages/hypertest-provider-cloud-aws/src/index.ts
+++ b/packages/hypertest-provider-cloud-aws/src/index.ts
@@ -351,7 +351,7 @@ export const HypertestProviderCloudAwsConfigSchema = z.object({
   lambdaUpdateMaxWaitTime: z.number().int().positive().optional().default(600),
 });
 
-type HypertestProviderCloudAwsConfig = z.infer<
+type HypertestProviderCloudAwsConfig = z.input<
   typeof HypertestProviderCloudAwsConfigSchema
 >;
 

--- a/packages/hypertest-provider-cloud-aws/src/index.ts
+++ b/packages/hypertest-provider-cloud-aws/src/index.ts
@@ -76,7 +76,7 @@ export const TestInvokeResponseSchema = z.discriminatedUnion('success', [
 ]);
 
 const HypertestProviderCloudAWS = (
-  settings: HypertestProviderCloudAwsConfig,
+  settings: ResolvedHypertestProviderCloudAwsConfig,
   config: ResolvedHypertestConfig,
 ): CloudProviderPlugin => {
   const lambdaClient = new LambdaClient({
@@ -348,12 +348,17 @@ export const HypertestProviderCloudAwsConfigSchema = z.object({
   ecrRegistry: z.string(),
   functionName: z.string(),
   bucketName: z.string(),
-  lambdaUpdateMaxWaitTime: z.number().int().positive().optional().default(600),
+  lambdaUpdateMaxWaitTime: z.number().int().positive().optional(),
 });
 
 type HypertestProviderCloudAwsConfig = z.input<
   typeof HypertestProviderCloudAwsConfigSchema
 >;
+
+type ResolvedHypertestProviderCloudAwsConfig =
+  HypertestProviderCloudAwsConfig & {
+    lambdaUpdateMaxWaitTime: number;
+  };
 
 const plugin = (
   options: HypertestProviderCloudAwsConfig,
@@ -402,7 +407,13 @@ const plugin = (
     },
   ],
   handler: (config) => {
-    return HypertestProviderCloudAWS(options, config);
+    return HypertestProviderCloudAWS(
+      {
+        ...options,
+        lambdaUpdateMaxWaitTime: 600,
+      },
+      config,
+    );
   },
 });
 

--- a/packages/hypertest-types/src/config-schema.ts
+++ b/packages/hypertest-types/src/config-schema.ts
@@ -56,7 +56,7 @@ export const ConfigSchema = z
     buildManifestFileName: ensureExtension(
       config.buildManifestFileName ?? MANIFEST_FILE_NAME,
     ),
-    driftDetectionPolicy: 'warning' as const,
+    driftDetectionPolicy: config.driftDetectionPolicy ?? ('warning' as const),
   }));
 
 /**

--- a/packages/hypertest-types/src/config-schema.ts
+++ b/packages/hypertest-types/src/config-schema.ts
@@ -42,7 +42,7 @@ export const ConfigSchema = z
     localBaseImageName: z.string().optional(),
     buildManifestFileName: z.string().optional(),
     driftDetectionPolicy: z
-      .union([z.literal('warning'), z.literal('error'), z.literal('salience')])
+      .union([z.literal('warning'), z.literal('error'), z.literal('silence')])
       .optional(),
     concurrency: z.number().int().default(1),
     loggerOptions: WinstonLoggerOptions.optional(),

--- a/packages/hypertest-types/src/config-schema.ts
+++ b/packages/hypertest-types/src/config-schema.ts
@@ -41,6 +41,9 @@ export const ConfigSchema = z
     localImageName: z.string().optional(),
     localBaseImageName: z.string().optional(),
     buildManifestFileName: z.string().optional(),
+    driftDetectionPolicy: z
+      .union([z.literal('warning'), z.literal('error'), z.literal('salience')])
+      .optional(),
     concurrency: z.number().int().default(1),
     loggerOptions: WinstonLoggerOptions.optional(),
     testRunner: PluginDefinitionSchema,
@@ -53,6 +56,7 @@ export const ConfigSchema = z
     buildManifestFileName: ensureExtension(
       config.buildManifestFileName ?? MANIFEST_FILE_NAME,
     ),
+    driftDetectionPolicy: 'warning' as const,
   }));
 
 /**

--- a/packages/hypertest-types/src/index.ts
+++ b/packages/hypertest-types/src/index.ts
@@ -14,6 +14,7 @@ export interface HypertestConfig<InvokePayloadContext> {
   localImageName?: string;
   localBaseImageName?: string;
   buildManifestFileName?: string;
+  driftDetectionPolicy?: 'warning' | 'error' | 'salience';
   concurrency?: number;
   loggerOptions?: winston.LoggerOptions;
   testRunner: TestRunnerPluginDefinition<InvokePayloadContext>;
@@ -25,6 +26,7 @@ export interface ResolvedHypertestConfig {
   localImageName: string;
   localBaseImageName: string;
   buildManifestFileName: string;
+  driftDetectionPolicy: 'warning' | 'error' | 'salience';
   concurrency: number;
   logger: winston.Logger;
 }

--- a/packages/hypertest-types/src/index.ts
+++ b/packages/hypertest-types/src/index.ts
@@ -14,7 +14,7 @@ export interface HypertestConfig<InvokePayloadContext> {
   localImageName?: string;
   localBaseImageName?: string;
   buildManifestFileName?: string;
-  driftDetectionPolicy?: 'warning' | 'error' | 'salience';
+  driftDetectionPolicy?: 'warning' | 'error' | 'silence';
   concurrency?: number;
   loggerOptions?: winston.LoggerOptions;
   testRunner: TestRunnerPluginDefinition<InvokePayloadContext>;
@@ -26,7 +26,7 @@ export interface ResolvedHypertestConfig {
   localImageName: string;
   localBaseImageName: string;
   buildManifestFileName: string;
-  driftDetectionPolicy: 'warning' | 'error' | 'salience';
+  driftDetectionPolicy: 'warning' | 'error' | 'silence';
   concurrency: number;
   logger: winston.Logger;
 }

--- a/packages/hypertest-types/src/test-runner-plugin.ts
+++ b/packages/hypertest-types/src/test-runner-plugin.ts
@@ -6,6 +6,7 @@ import type {
 
 export interface TestRunnerPlugin<InvokePayloadContext> {
   getInvokePayloadContext: () => Promise<InvokePayloadContext[]>;
+  getTestDir: () => Promise<string>;
   buildImage: () => Promise<void>;
 }
 


### PR DESCRIPTION
I used custom script for hasing instead of using lib like `folder-hash` because I want Us to have full control on this process.
It is fairly easy to implement if we do not need to use streams (files are small). This gives us posibility to normalize files content so the process can be OS agnostic.