### PR TITLE
Create `hypertest.results.json` file after invoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ dist
 
 # hypertest
 .hypertest
-hypertest.results.json
+hypertest.results.json # default resultsFileName — update if you use a custom name
 
 # Claude
 .claude

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 
 # hypertest
 .hypertest
+hypertest.results.json
 
 # Claude
 .claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Two plugin interfaces in `hypertest-types`:
 - `pushImage()`: Push built image to registry
 - `invoke(payload)`: Invoke cloud function
 - `updateLambdaImage()`: Update Lambda with new image
+- `uploadRunResult(runId, content)`: Upload serialized `hypertest.results.json` to cloud storage at `{runId}/hypertest.results.json`
 
 ### Execution Flow
 
@@ -72,13 +73,16 @@ Two plugin interfaces in `hypertest-types`:
 1. Generate unique `runId`
 2. Test runner creates payloads (one per test file)
 3. Invoke Lambdas concurrently (up to `concurrency` limit)
-4. Collect results from S3
+4. Collect results from cloud storage
+5. Write `hypertest.results.json` locally (CWD) and upload to cloud storage at `{runId}/hypertest.results.json`
 
 ### Key Files
 - CLI entry: `packages/hypertest-core/src/cli.ts`
 - Core orchestration: `packages/hypertest-core/src/index.ts`
 - Type definitions: `packages/hypertest-types/src/index.ts`
+- Run result types: `packages/hypertest-types/src/run-result.ts` (`HypertestRunResult`, `HypertestTestResult`)
 - Lambda handler: `packages/hypertest-runner-aws-playwright/src/index.ts`
+- Playwright report parser: `packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts`
 
 ### Configuration
 Projects use `hypertest.config.js`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Two plugin interfaces in `hypertest-types`:
 - `pushImage()`: Push built image to registry
 - `invoke(payload)`: Invoke cloud function
 - `updateLambdaImage()`: Update Lambda with new image
-- `uploadRunResult(runId, content)`: Upload serialized `hypertest.results.json` to cloud storage at `{runId}/hypertest.results.json`
+- `uploadRunResult(runId, content)`: Upload serialized results file to cloud storage at `{runId}/{resultsFileName}` (default: `hypertest.results.json`)
 
 ### Execution Flow
 
@@ -74,7 +74,7 @@ Two plugin interfaces in `hypertest-types`:
 2. Test runner creates payloads (one per test file)
 3. Invoke Lambdas concurrently (up to `concurrency` limit)
 4. Collect results from cloud storage
-5. Write `hypertest.results.json` locally (CWD) and upload to cloud storage at `{runId}/hypertest.results.json`
+5. Write results file locally (CWD) and upload to cloud storage at `{runId}/{resultsFileName}` (default: `hypertest.results.json`)
 
 ### Key Files
 - CLI entry: `packages/hypertest-core/src/cli.ts`

--- a/packages/hypertest-core/src/index.ts
+++ b/packages/hypertest-core/src/index.ts
@@ -7,6 +7,7 @@ import type {
   HypertestRunResult,
   HypertestTestResult,
   ResolvedHypertestConfig,
+  TestInvokeResponse,
   TestRunnerPlugin,
 } from '@hypertest/hypertest-types';
 import { loadConfig } from './config.js';
@@ -19,6 +20,33 @@ interface HypertestCore {
 }
 
 export const defineConfig = <T>(config: HypertestConfig<T>) => config;
+
+const parseTestResult = (
+  testId: string,
+  invokeResponse: TestInvokeResponse,
+  invokeStart: Date,
+  invokeEnd: Date,
+): HypertestTestResult => ({
+  testId,
+  name: invokeResponse.name ?? 'unknown',
+  filePath: invokeResponse.filePath ?? 'unknown',
+  status:
+    invokeResponse.success === true
+      ? 'success'
+      : invokeResponse.success === 'skipped'
+        ? 'skipped'
+        : 'failed',
+  startDate: invokeStart.toISOString(),
+  endDate: invokeEnd.toISOString(),
+  duration:
+    invokeResponse.success === true
+      ? invokeResponse.duration
+      : invokeEnd.getTime() - invokeStart.getTime(),
+  error:
+    invokeResponse.success === false
+      ? { message: invokeResponse.message, stackTrace: invokeResponse.stackTrace }
+      : undefined,
+});
 
 export const setupHypertest = async ({ dryRun }: CommandOptions) => {
   const { config, ...providers } = await loadConfig();
@@ -79,43 +107,22 @@ export const HypertestCore = <InvokePayloadContext>(options: {
         }),
       );
 
-      const results = await promiseMap(
+      const invokeResponses = await promiseMap(
         functionInvokePayloads,
         async (payload) => {
           const invokeStart = new Date();
-          const result = await options.cloudProvider.invoke(payload);
+          const invokeResponse = await options.cloudProvider.invoke(payload);
           const invokeEnd = new Date();
-          return { ...payload, result, invokeStart, invokeEnd };
+          return { ...payload, invokeResponse, invokeStart, invokeEnd };
         },
         { concurrency: options.config.concurrency },
       );
 
       const runEndDate = new Date();
 
-      const testResults: HypertestTestResult[] = results.map(
-        ({ testId, result, invokeStart, invokeEnd }) => {
-          return {
-            testId,
-            name: result.name ?? 'unknown',
-            filePath: result.filePath ?? 'unknown',
-            status:
-              result.success === true
-                ? 'success'
-                : result.success === 'skipped'
-                  ? 'skipped'
-                  : 'failed',
-            startDate: invokeStart.toISOString(),
-            endDate: invokeEnd.toISOString(),
-            duration:
-              result.success === true
-                ? result.duration
-                : invokeEnd.getTime() - invokeStart.getTime(),
-            error:
-              result.success === false
-                ? { message: result.message, stackTrace: result.stackTrace }
-                : undefined,
-          };
-        },
+      const testResults: HypertestTestResult[] = invokeResponses.map(
+        ({ testId, invokeResponse, invokeStart, invokeEnd }) =>
+          parseTestResult(testId, invokeResponse, invokeStart, invokeEnd),
       );
 
       const runResult: HypertestRunResult = {
@@ -133,22 +140,22 @@ export const HypertestCore = <InvokePayloadContext>(options: {
       };
 
       const json = JSON.stringify(runResult, null, 2);
-      const localPath = path.join(process.cwd(), 'hypertest.results.json');
+      const localPath = path.join(process.cwd(), options.config.resultsFileName);
 
       await writeFile(localPath, json, 'utf-8');
       await options.cloudProvider.uploadRunResult(runId, json);
 
       options.config.logger.info(
-        `Results written to ${localPath} and uploaded to cloud storage at ${runId}/hypertest.results.json`,
+        `Results written to ${localPath} and uploaded to cloud storage at ${runId}/${options.config.resultsFileName}`,
       );
 
       options.config.logger.info(
-        `Functions invoked successfully. Run id: ${results[0].runId}`,
+        `Functions invoked successfully. Run id: ${invokeResponses[0].runId}`,
       );
-      for (const { result, testId } of results) {
+      for (const { invokeResponse, testId } of invokeResponses) {
         options.config.logger.verbose(`TestId: ${testId}`);
         options.config.logger.verbose(
-          `Test results: ${JSON.stringify(result, null, 2)}`,
+          `Invoke response: ${JSON.stringify(invokeResponse, null, 2)}`,
         );
       }
     },

--- a/packages/hypertest-core/src/index.ts
+++ b/packages/hypertest-core/src/index.ts
@@ -125,6 +125,14 @@ export const HypertestCore = <InvokePayloadContext>(options: {
           parseTestResult(testId, invokeResponse, invokeStart, invokeEnd),
       );
 
+      const counts = testResults.reduce(
+        (counts, testResult) => {
+          counts[testResult.status]++;
+          return counts;
+        },
+        { success: 0, skipped: 0, failed: 0 },
+      );
+
       const runResult: HypertestRunResult = {
         runId,
         startDate: runStartDate.toISOString(),
@@ -132,11 +140,9 @@ export const HypertestCore = <InvokePayloadContext>(options: {
         duration: runEndDate.getTime() - runStartDate.getTime(),
         tests: {
           total: testResults.length,
-          success: testResults.filter((t) => t.status === 'success').length,
-          skipped: testResults.filter((t) => t.status === 'skipped').length,
-          failed: testResults.filter((t) => t.status === 'failed').length,
+          ...counts,
         },
-        results: testResults,
+        testResults,
       };
 
       const json = JSON.stringify(runResult, null, 2);
@@ -150,7 +156,7 @@ export const HypertestCore = <InvokePayloadContext>(options: {
       );
 
       options.config.logger.info(
-        `Functions invoked successfully. Run id: ${invokeResponses[0].runId}`,
+        `Functions invoked successfully. Run id: ${runId}`,
       );
       for (const { invokeResponse, testId } of invokeResponses) {
         options.config.logger.verbose(`TestId: ${testId}`);

--- a/packages/hypertest-core/src/index.ts
+++ b/packages/hypertest-core/src/index.ts
@@ -1,7 +1,11 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import type {
   CloudProviderPlugin,
   CommandOptions,
   HypertestConfig,
+  HypertestRunResult,
+  HypertestTestResult,
   ResolvedHypertestConfig,
   TestRunnerPlugin,
 } from '@hypertest/hypertest-types';
@@ -46,6 +50,8 @@ export const HypertestCore = <InvokePayloadContext>(options: {
       options.config.logger.info('Invoking cloud functions');
 
       const runId = crypto.randomUUID();
+      const runStartDate = new Date();
+
       const manifest = await options.cloudProvider.pullManifest();
       const testDirHash = getTestDirHash();
 
@@ -65,11 +71,65 @@ export const HypertestCore = <InvokePayloadContext>(options: {
 
       const results = await promiseMap(
         functionInvokePayloads,
-        async (payload) => ({
-          ...payload,
-          result: await options.cloudProvider.invoke(payload),
-        }),
+        async (payload) => {
+          const invokeStart = new Date();
+          const result = await options.cloudProvider.invoke(payload);
+          const invokeEnd = new Date();
+          return { ...payload, result, invokeStart, invokeEnd };
+        },
         { concurrency: options.config.concurrency },
+      );
+
+      const runEndDate = new Date();
+
+      const testResults: HypertestTestResult[] = results.map(
+        ({ testId, result, invokeStart, invokeEnd }) => {
+          return {
+            testId,
+            name: result.name ?? 'unknown',
+            filePath: result.filePath ?? 'unknown',
+            status:
+              result.success === true
+                ? 'success'
+                : result.success === 'skipped'
+                  ? 'skipped'
+                  : 'failed',
+            startDate: invokeStart.toISOString(),
+            endDate: invokeEnd.toISOString(),
+            duration:
+              result.success === true
+                ? result.duration
+                : invokeEnd.getTime() - invokeStart.getTime(),
+            error:
+              result.success === false
+                ? { message: result.message, stackTrace: result.stackTrace }
+                : undefined,
+          };
+        },
+      );
+
+      const runResult: HypertestRunResult = {
+        runId,
+        startDate: runStartDate.toISOString(),
+        endDate: runEndDate.toISOString(),
+        duration: runEndDate.getTime() - runStartDate.getTime(),
+        tests: {
+          total: testResults.length,
+          success: testResults.filter((t) => t.status === 'success').length,
+          skipped: testResults.filter((t) => t.status === 'skipped').length,
+          failed: testResults.filter((t) => t.status === 'failed').length,
+        },
+        results: testResults,
+      };
+
+      const json = JSON.stringify(runResult, null, 2);
+      const localPath = path.join(process.cwd(), 'hypertest.results.json');
+
+      await writeFile(localPath, json, 'utf-8');
+      await options.cloudProvider.uploadRunResult(runId, json);
+
+      options.config.logger.info(
+        `Results written to ${localPath} and uploaded to cloud storage at ${runId}/hypertest.results.json`,
       );
 
       options.config.logger.info(

--- a/packages/hypertest-docs/docs/.vitepress/config.js
+++ b/packages/hypertest-docs/docs/.vitepress/config.js
@@ -18,6 +18,7 @@ export default {
           { text: 'Installation', link: '/getting-started/installation' },
           { text: 'Configuration', link: '/getting-started/configuration' },
           { text: 'Usage', link: '/getting-started/usage' },
+          { text: 'Results', link: '/getting-started/results' },
         ],
       },
       {

--- a/packages/hypertest-docs/docs/getting-started/configuration.md
+++ b/packages/hypertest-docs/docs/getting-started/configuration.md
@@ -33,6 +33,9 @@ export default defineConfig({
   // Custom hypertest build manifest filename
   buildManifestFileName: 'hypertest.manifest.json',
 
+  // Custom results filename written locally and to cloud storage after invoke
+  resultsFileName: 'hypertest.results.json',
+
   // Specifies the action to take if drift is detected between the deployed manifest and the local test suite. Can be: 'silence', 'warning', or 'error'. Defaults to 'warning'.
   driftDetectionPolicy: 'warning',
 
@@ -63,6 +66,8 @@ export default defineConfig({
 | `imageName` | string | Yes | - | Name for your Docker image with test files |
 | `localImageName` | string | No | - | Name for local Docker image used during build |
 | `localBaseImageName` | string | No | - | Name for the local base image with hypertest runner |
+| `resultsFileName` | string | No | `hypertest.results.json` | Filename for the results file written locally and to cloud storage after every invoke run |
+| `buildManifestFileName` | string | No | `hypertest.manifest.json` | Filename for the build manifest stored in cloud storage |
 
 ::: tip
 Higher `concurrency` values mean faster execution but more cloud resource usage. Start with 10-30 and increase based on your AWS Lambda quotas.

--- a/packages/hypertest-docs/docs/getting-started/results.md
+++ b/packages/hypertest-docs/docs/getting-started/results.md
@@ -10,7 +10,7 @@ next:
 
 # Results
 
-After every `hypertest invoke` run, hypertest writes a `hypertest.results.json` file summarising the entire run and each individual test outcome.
+After every `hypertest invoke` run, hypertest writes a results file (default: `hypertest.results.json`) summarising the entire run and each individual test outcome.
 
 ## Where results are saved
 
@@ -18,8 +18,10 @@ Results are saved in two places automatically:
 
 | Location | Path | Purpose |
 |---|---|---|
-| **Local** | `./hypertest.results.json` (your working directory) | Immediate access — readable by CI systems, developers, and reporting tools |
-| **Cloud storage** | `{runId}/hypertest.results.json` | Durable storage alongside per-test artifacts for cross-run history and future tooling |
+| **Local** | `./{resultsFileName}` (your working directory) | Immediate access — readable by CI systems, developers, and reporting tools |
+| **Cloud storage** | `{runId}/{resultsFileName}` | Durable storage alongside per-test artifacts for cross-run history and future tooling |
+
+The filename defaults to `hypertest.results.json` and can be customised via the [`resultsFileName`](/getting-started/configuration#core-settings) config option.
 
 ## File structure
 
@@ -103,7 +105,7 @@ Results are saved in two places automatically:
 
 ## Using results in CI/CD
 
-The local `hypertest.results.json` file is available immediately after `invoke` completes. You can upload it as a CI artifact for inspection or feed it into reporting tools.
+The local results file is available immediately after `invoke` completes. You can upload it as a CI artifact for inspection or feed it into reporting tools.
 
 ### GitHub Actions example
 
@@ -116,7 +118,7 @@ The local `hypertest.results.json` file is available immediately after `invoke` 
   uses: actions/upload-artifact@v4
   with:
     name: hypertest-results
-    path: hypertest.results.json
+    path: hypertest.results.json  # update if you set a custom resultsFileName
 ```
 
 ::: tip Use `if: always()`
@@ -130,7 +132,7 @@ Each test entry in `results` carries a `testId` that matches the path structure 
 ```
 {cloud-bucket}/
 └── {runId}/
-    ├── hypertest.results.json
+    ├── {resultsFileName}   (default: hypertest.results.json)
     └── {testId}/
         └── .../
 ```

--- a/packages/hypertest-docs/docs/getting-started/results.md
+++ b/packages/hypertest-docs/docs/getting-started/results.md
@@ -1,0 +1,136 @@
+---
+outline: deep
+prev:
+  text: Usage
+  link: /getting-started/usage
+next:
+  text: Plugins overview
+  link: /plugins/overview
+---
+
+# Results
+
+After every `hypertest invoke` run, hypertest writes a `hypertest.results.json` file summarising the entire run and each individual test outcome.
+
+## Where results are saved
+
+Results are saved in two places automatically:
+
+| Location | Path | Purpose |
+|---|---|---|
+| **Local** | `./hypertest.results.json` (your working directory) | Immediate access — readable by CI systems, developers, and reporting tools |
+| **Cloud storage** | `{runId}/hypertest.results.json` | Durable storage alongside per-test artifacts for cross-run history and future tooling |
+
+## File structure
+
+```json
+{
+  "runId": "a1b2c3d4-...",
+  "startDate": "2026-04-20T10:00:00.000Z",
+  "endDate": "2026-04-20T10:00:47.321Z",
+  "duration": 47321,
+  "tests": {
+    "total": 34,
+    "success": 30,
+    "skipped": 1,
+    "failed": 3
+  },
+  "results": [
+    {
+      "testId": "e5f6g7h8-...",
+      "name": "Todo App > should add a new item",
+      "filePath": "tests/todo.spec.ts",
+      "status": "success",
+      "startDate": "2026-04-20T10:00:01.100Z",
+      "endDate": "2026-04-20T10:00:03.850Z",
+      "duration": 2104
+    },
+    {
+      "testId": "i9j0k1l2-...",
+      "name": "Todo App > should edit an item",
+      "filePath": "tests/todo.spec.ts",
+      "status": "failed",
+      "startDate": "2026-04-20T10:00:01.200Z",
+      "endDate": "2026-04-20T10:00:06.900Z",
+      "duration": 5700,
+      "error": {
+        "message": "Expected 'Buy milk' to equal 'Buy bread'",
+        "stackTrace": "Error: Expected 'Buy milk' to equal 'Buy bread'\n    at ..."
+      }
+    },
+    {
+      "testId": "m3n4o5p6-...",
+      "name": "Todo App > should mark all items complete",
+      "filePath": "tests/todo.spec.ts",
+      "status": "skipped",
+      "startDate": "2026-04-20T10:00:01.300Z",
+      "endDate": "2026-04-20T10:00:01.850Z",
+      "duration": 550
+    }
+  ]
+}
+```
+
+## Field reference
+
+### Run-level fields
+
+| Field | Type | Description |
+|---|---|---|
+| `runId` | `string` | Unique UUID for this invoke run. Used to locate cloud artifacts at `{runId}/`. |
+| `startDate` | `string` | ISO 8601 timestamp when the run started (before cloud manifest is fetched). |
+| `endDate` | `string` | ISO 8601 timestamp when all invocations completed. |
+| `duration` | `number` | Total run duration in milliseconds. |
+| `tests.total` | `number` | Total number of tests invoked. |
+| `tests.success` | `number` | Number of tests that passed. |
+| `tests.skipped` | `number` | Number of tests that were skipped. |
+| `tests.failed` | `number` | Number of tests that failed. |
+| `results` | `array` | Per-test result entries (one per test invocation). |
+
+### Per-test fields
+
+| Field | Type | Description |
+|---|---|---|
+| `testId` | `string` | Unique UUID for this test invocation. Used to locate per-test artifacts at `{runId}/{testId}/`. |
+| `name` | `string` | Full test name including suite hierarchy, e.g. `Suite > Nested > Test name`. |
+| `filePath` | `string` | Path to the test file relative to the project root. |
+| `status` | `string` | Test outcome: `"success"`, `"failed"`, or `"skipped"`. |
+| `startDate` | `string` | ISO 8601 timestamp when this test invocation started. |
+| `endDate` | `string` | ISO 8601 timestamp when this test invocation completed. |
+| `duration` | `number` | Duration in milliseconds. For successful tests, this is the Playwright test execution time. For failed and skipped tests, this is the total invocation time measured by the orchestrator. |
+| `error.message` | `string` | Error message from the test failure. Only present when `status` is `"failed"`. |
+| `error.stackTrace` | `string` | Full stack trace from the test failure. Only present when `status` is `"failed"`. |
+
+## Using results in CI/CD
+
+The local `hypertest.results.json` file is available immediately after `invoke` completes. You can upload it as a CI artifact for inspection or feed it into reporting tools.
+
+### GitHub Actions example
+
+```yaml
+- name: Run tests
+  run: npx hypertest invoke
+
+- name: Upload results
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: hypertest-results
+    path: hypertest.results.json
+```
+
+::: tip Use `if: always()`
+Upload the results file even when tests fail so you can inspect which tests caused the failure.
+:::
+
+## Correlating results with artifacts
+
+Each test entry in `results` carries a `testId` that matches the path structure in cloud storage. Use it to link a failed test to its screenshots, traces, or videos:
+
+```
+{cloud-bucket}/
+└── {runId}/
+    ├── hypertest.results.json
+    └── {testId}/
+        └── .../
+```

--- a/packages/hypertest-docs/docs/getting-started/results.md
+++ b/packages/hypertest-docs/docs/getting-started/results.md
@@ -37,7 +37,7 @@ The filename defaults to `hypertest.results.json` and can be customised via the 
     "skipped": 1,
     "failed": 3
   },
-  "results": [
+  "testResults": [
     {
       "testId": "e5f6g7h8-...",
       "name": "Todo App > should add a new item",
@@ -87,7 +87,7 @@ The filename defaults to `hypertest.results.json` and can be customised via the 
 | `tests.success` | `number` | Number of tests that passed. |
 | `tests.skipped` | `number` | Number of tests that were skipped. |
 | `tests.failed` | `number` | Number of tests that failed. |
-| `results` | `array` | Per-test result entries (one per test invocation). |
+| `testResults` | `array` | Per-test result entries (one per test invocation). |
 
 ### Per-test fields
 

--- a/packages/hypertest-docs/docs/getting-started/usage.md
+++ b/packages/hypertest-docs/docs/getting-started/usage.md
@@ -1,8 +1,8 @@
 ---
 outline: deep
 next:
-  text: Plugins overview
-  link: /plugins/overview
+  text: Results
+  link: /getting-started/results
 prev:
   text: Configuration
   link: /getting-started/configuration
@@ -59,7 +59,10 @@ The `invoke` command:
 1. **Analyzes tests** - Scans the test directory and generates a content hash.
 2. **Validates state** - Compares the local hash and deployed image digest against the manifest (mismatch handling is TODO).
 3. **Invokes functions** - Builds payloads based on the manifest and launches cloud functions in parallel (up to `concurrency` limit).
-4. **Collects results** - Gathers test results and artifacts from bucket (like S3 for AWS).
+4. **Collects results** - Gathers test results and artifacts from cloud storage (like S3 for AWS).
+5. **Writes results file** - Saves `hypertest.results.json` locally and uploads it to cloud storage.
+
+See [Results](/getting-started/results) for the full file structure.
 
 ## Development workflow
 
@@ -76,7 +79,7 @@ npx hypertest deploy
 # 4. Run tests in cloud
 npx hypertest invoke
 
-# 5. Check results in S3 bucket
+# 5. Inspect hypertest.results.json
 ```
 
 ::: tip Local testing first
@@ -85,13 +88,14 @@ Always run your tests locally with `npx playwright test` before deploying to cat
 
 ## Working with test artifacts
 
-hypertest automatically handles test artifacts like screenshots, videos, and reports. Artifacts are saved to your configured S3 bucket organized by run ID.
+hypertest automatically handles test artifacts like screenshots, videos, and reports. Artifacts are saved to your configured cloud storage (like S3 for AWS) organized by run ID.
 
-### Artifact structure in S3
+### Artifact structure in cloud storage
 
 ```
-s3://your-bucket/
+{cloud-bucket}/
 └── {runId}/
+    ├── hypertest.results.json
     └── {testId}/
         ├── playwright-results.json
         ├── screenshots/
@@ -162,6 +166,13 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: eu-central-1
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hypertest-results
+          path: hypertest.results.json
 ```
 
 ::: warning

--- a/packages/hypertest-provider-cloud-aws/src/index.ts
+++ b/packages/hypertest-provider-cloud-aws/src/index.ts
@@ -26,6 +26,7 @@ import {
   type ResolvedHypertestConfig,
   type ImageBuildManifest,
   ImageBuildManifestSchema,
+  TestInvokeResponseSchema,
 } from '@hypertest/hypertest-types';
 import type winston from 'winston';
 import { z } from 'zod';
@@ -59,26 +60,6 @@ const getEcrAuth = async (ecrClient: ECRClient, logger: winston.Logger) => {
   };
 };
 
-export const TestInvokeResponseSchema = z.discriminatedUnion('success', [
-  z.object({
-    success: z.literal(true),
-    name: z.string(),
-    filePath: z.string(),
-    duration: z.number(),
-  }),
-  z.object({
-    success: z.literal('skipped'),
-    name: z.string(),
-    filePath: z.string(),
-  }),
-  z.object({
-    success: z.literal(false),
-    message: z.string(),
-    name: z.string().optional(),
-    filePath: z.string().optional(),
-    stackTrace: z.string().optional(),
-  }),
-]);
 
 const HypertestProviderCloudAWS = (
   settings: ResolvedHypertestProviderCloudAwsConfig,
@@ -328,16 +309,17 @@ const HypertestProviderCloudAWS = (
     },
     uploadRunResult: async (runId, content) => {
       try {
+        const s3Key = `${runId}/${config.resultsFileName}`;
         const command = new PutObjectCommand({
           Bucket: settings.bucketName,
-          Key: `${runId}/hypertest.results.json`,
+          Key: s3Key,
           Body: content,
           ContentType: 'application/json',
         });
 
         await s3Client.send(command);
         config.logger.verbose(
-          `hypertest.results.json was successfully uploaded to bucket ${settings.bucketName} at ${runId}/hypertest.results.json.`,
+          `${config.resultsFileName} was successfully uploaded to bucket ${settings.bucketName} at ${s3Key}.`,
         );
       } catch (error) {
         config.logger.error('Error while uploading run result:', error);

--- a/packages/hypertest-provider-cloud-aws/src/index.ts
+++ b/packages/hypertest-provider-cloud-aws/src/index.ts
@@ -67,6 +67,11 @@ export const TestInvokeResponseSchema = z.discriminatedUnion('success', [
     duration: z.number(),
   }),
   z.object({
+    success: z.literal('skipped'),
+    name: z.string(),
+    filePath: z.string(),
+  }),
+  z.object({
     success: z.literal(false),
     message: z.string(),
     name: z.string().optional(),
@@ -318,6 +323,24 @@ const HypertestProviderCloudAWS = (
         );
       } catch (error) {
         config.logger.error('Error while updating manifest:', error);
+        process.exit(1);
+      }
+    },
+    uploadRunResult: async (runId, content) => {
+      try {
+        const command = new PutObjectCommand({
+          Bucket: settings.bucketName,
+          Key: `${runId}/hypertest.results.json`,
+          Body: content,
+          ContentType: 'application/json',
+        });
+
+        await s3Client.send(command);
+        config.logger.verbose(
+          `hypertest.results.json was successfully uploaded to bucket ${settings.bucketName} at ${runId}/hypertest.results.json.`,
+        );
+      } catch (error) {
+        config.logger.error('Error while uploading run result:', error);
         process.exit(1);
       }
     },

--- a/packages/hypertest-provider-cloud-aws/src/index.ts
+++ b/packages/hypertest-provider-cloud-aws/src/index.ts
@@ -60,7 +60,6 @@ const getEcrAuth = async (ecrClient: ECRClient, logger: winston.Logger) => {
   };
 };
 
-
 const HypertestProviderCloudAWS = (
   settings: ResolvedHypertestProviderCloudAwsConfig,
   config: ResolvedHypertestConfig,

--- a/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
+++ b/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
@@ -61,11 +61,8 @@ export const parsePlaywrightReport = (
                 result?.error?.stack || 'Unable to retrieve stack trace',
             });
           } else if (result?.status === 'skipped') {
-            extractedData.push({
-              success: 'skipped',
-              name: responseBase.name,
-              filePath: responseBase.filePath,
-            });
+            const { name, filePath } = responseBase;
+            extractedData.push({ success: 'skipped', name, filePath });
           } else {
             extractedData.push({
               ...responseBase,

--- a/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
+++ b/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
@@ -60,6 +60,12 @@ export const parsePlaywrightReport = (
               stackTrace:
                 result?.error?.stack || 'Unable to retrieve stack trace',
             });
+          } else if (result?.status === 'skipped') {
+            extractedData.push({
+              success: 'skipped',
+              name: responseBase.name,
+              filePath: responseBase.filePath,
+            });
           } else {
             extractedData.push({
               ...responseBase,

--- a/packages/hypertest-types/src/cloud-provider.ts
+++ b/packages/hypertest-types/src/cloud-provider.ts
@@ -32,6 +32,15 @@ export interface CloudProviderPlugin<InvokePayloadContext = unknown> {
     payload: InvokePayload<InvokePayloadContext>,
   ) => Promise<TestInvokeResponse>;
   /**
+   * Uploads the serialized `hypertest.results.json` content to cloud storage
+   * for durable, cross-run access. The file is stored alongside per-test
+   * artifacts at `{runId}/hypertest.results.json`.
+   *
+   * @param runId - The unique identifier for the invoke run.
+   * @param content - The serialized JSON string of {@link HypertestRunResult}.
+   */
+  uploadRunResult: (runId: string, content: string) => Promise<void>;
+  /**
    * Updates the cloud function to a newly pushed image and waits until
    * the update is fully applied before resolving. Implementations should
    * poll or subscribe until the function is confirmed active.

--- a/packages/hypertest-types/src/cloud-provider.ts
+++ b/packages/hypertest-types/src/cloud-provider.ts
@@ -11,7 +11,12 @@ export type TestInvokeResponse =
       success: true;
       name: string;
       filePath: string;
-      duration: number; //in ms
+      duration: number; // in ms
+    }
+  | {
+      success: 'skipped';
+      name: string;
+      filePath: string;
     }
   | {
       success: false;

--- a/packages/hypertest-types/src/cloud-provider.ts
+++ b/packages/hypertest-types/src/cloud-provider.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type {
   CommandOptions,
   InvokePayload,
@@ -6,25 +7,29 @@ import type {
 } from './index.js';
 import type { ImageBuildManifest } from './manifest.js';
 
-export type TestInvokeResponse =
-  | {
-      success: true;
-      name: string;
-      filePath: string;
-      duration: number; // in ms
-    }
-  | {
-      success: 'skipped';
-      name: string;
-      filePath: string;
-    }
-  | {
-      success: false;
-      message: string;
-      name?: string;
-      filePath?: string;
-      stackTrace?: string;
-    };
+export const TestInvokeResponseSchema = z.discriminatedUnion('success', [
+  z.object({
+    success: z.literal(true),
+    name: z.string(),
+    filePath: z.string(),
+    duration: z.number(),
+  }),
+  z.object({
+    success: z.literal('skipped'),
+    name: z.string(),
+    filePath: z.string(),
+  }),
+  z.object({
+    success: z.literal(false),
+    message: z.string(),
+    name: z.string().optional(),
+    filePath: z.string().optional(),
+    stackTrace: z.string().optional(),
+  }),
+]);
+
+export type TestInvokeResponse = z.infer<typeof TestInvokeResponseSchema>;
+
 export interface CloudProviderPlugin<InvokePayloadContext = unknown> {
   pullBaseImage: () => Promise<void>;
   pushImage: () => Promise<void>;
@@ -32,9 +37,9 @@ export interface CloudProviderPlugin<InvokePayloadContext = unknown> {
     payload: InvokePayload<InvokePayloadContext>,
   ) => Promise<TestInvokeResponse>;
   /**
-   * Uploads the serialized `hypertest.results.json` content to cloud storage
-   * for durable, cross-run access. The file is stored alongside per-test
-   * artifacts at `{runId}/hypertest.results.json`.
+   * Uploads the serialized results file content to cloud storage for durable,
+   * cross-run access. The file is stored alongside per-test artifacts at
+   * `{runId}/{resultsFileName}`.
    *
    * @param runId - The unique identifier for the invoke run.
    * @param content - The serialized JSON string of {@link HypertestRunResult}.

--- a/packages/hypertest-types/src/config-schema.ts
+++ b/packages/hypertest-types/src/config-schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 const LOCAL_BASE_IMAGE_NAME = 'hypertest/local-base-playwright';
 const MANIFEST_FILE_NAME = 'hypertest.manifest.json';
+const RESULTS_FILE_NAME = 'hypertest.results.json';
 
 const PluginDefinitionSchema = z.object({
   name: z.string(),
@@ -41,6 +42,7 @@ export const ConfigSchema = z
     localImageName: z.string().optional(),
     localBaseImageName: z.string().optional(),
     buildManifestFileName: z.string().optional(),
+    resultsFileName: z.string().optional(),
     driftDetectionPolicy: z
       .union([z.literal('warning'), z.literal('error'), z.literal('silence')])
       .optional(),
@@ -55,6 +57,9 @@ export const ConfigSchema = z
     localBaseImageName: config.localBaseImageName ?? LOCAL_BASE_IMAGE_NAME,
     buildManifestFileName: ensureExtension(
       config.buildManifestFileName ?? MANIFEST_FILE_NAME,
+    ),
+    resultsFileName: ensureExtension(
+      config.resultsFileName ?? RESULTS_FILE_NAME,
     ),
     driftDetectionPolicy: config.driftDetectionPolicy ?? ('warning' as const),
   }));

--- a/packages/hypertest-types/src/index.ts
+++ b/packages/hypertest-types/src/index.ts
@@ -62,3 +62,5 @@ export * from './cli-doctor.js';
 export * from './manifest-schema.js';
 // biome-ignore lint/performance/noReExportAll: <explanation>
 export * from './manifest.js';
+// biome-ignore lint/performance/noReExportAll: <explanation>
+export * from './run-result.js';

--- a/packages/hypertest-types/src/index.ts
+++ b/packages/hypertest-types/src/index.ts
@@ -14,6 +14,7 @@ export interface HypertestConfig<InvokePayloadContext> {
   localImageName?: string;
   localBaseImageName?: string;
   buildManifestFileName?: string;
+  resultsFileName?: string;
   driftDetectionPolicy?: 'warning' | 'error' | 'silence';
   concurrency?: number;
   loggerOptions?: winston.LoggerOptions;
@@ -26,6 +27,7 @@ export interface ResolvedHypertestConfig {
   localImageName: string;
   localBaseImageName: string;
   buildManifestFileName: string;
+  resultsFileName: string;
   driftDetectionPolicy: 'warning' | 'error' | 'silence';
   concurrency: number;
   logger: winston.Logger;

--- a/packages/hypertest-types/src/run-result.ts
+++ b/packages/hypertest-types/src/run-result.ts
@@ -23,5 +23,5 @@ export interface HypertestRunResult {
     skipped: number;
     failed: number;
   };
-  results: HypertestTestResult[];
+  testResults: HypertestTestResult[];
 }

--- a/packages/hypertest-types/src/run-result.ts
+++ b/packages/hypertest-types/src/run-result.ts
@@ -1,0 +1,27 @@
+export interface HypertestTestResult {
+  testId: string;
+  name: string;
+  filePath: string;
+  status: 'success' | 'failed' | 'skipped';
+  startDate: string;
+  endDate: string;
+  duration: number; // in ms
+  error?: {
+    message: string;
+    stackTrace?: string;
+  };
+}
+
+export interface HypertestRunResult {
+  runId: string;
+  startDate: string;
+  endDate: string;
+  duration: number; // in ms
+  tests: {
+    total: number;
+    success: number;
+    skipped: number;
+    failed: number;
+  };
+  results: HypertestTestResult[];
+}


### PR DESCRIPTION
## Summary

  - Adds a results file (default: `hypertest.results.json`) written locally (CWD) and uploaded to cloud storage at `{runId}/{resultsFileName}` after
  every `hypertest invoke` run
  - Introduces `HypertestRunResult` and `HypertestTestResult` types in `hypertest-types` capturing run-level timing, test counts, and per-test
  status/duration/error
  - Extends `TestInvokeResponse` with a `skipped` union arm and updates `parsePlaywrightReport` + `TestInvokeResponseSchema` to handle skipped
  Playwright tests end-to-end
  - Moves `TestInvokeResponseSchema` from `hypertest-provider-cloud-aws` to `hypertest-types` (next to `TestInvokeResponse`); the type is now derived
  via `z.infer` to keep schema and type in sync
  - Adds `uploadRunResult` method to `CloudProviderPlugin` interface, implemented in the AWS provider via `PutObjectCommand`
  - Adds optional `resultsFileName` config property (default `'hypertest.results.json'`) to allow custom output filenames; used for both the local
  write path and the S3 key
  - Extracts `parseTestResult(testId, invokeResponse, invokeStart, invokeEnd)` as a pure helper in core, replacing an inline 15-line map callback
  - Renames invoke-level variables from `results`/`result` to `invokeResponses`/`invokeResponse` to clearly distinguish raw Lambda responses from
  final `HypertestTestResult` objects
  - Documents the results file in a new **Getting Started → Results** docs page with full field reference, example JSON, CI/CD integration guide, and
  artifact correlation

  ## File

  ```json
  {
    "runId": "82634b68-e54a-433d-8674-25c038ee57c2",
    "startDate": "2026-04-20T18:00:09.017Z",
    "endDate": "2026-04-20T18:01:05.798Z",
    "duration": 56781,
    "tests": {
      "total": 4,
      "success": 2,
      "skipped": 0,
      "failed": 2
    },
    "results": [
      {
        "testId": "fcf09839-4cde-47d7-9eb6-d7d8fd3d82fb",
        "name": "demo-todo-app.spec.ts > New Todo > should allow me to add todo items",
        "filePath": "demo-todo-app.spec.ts",
        "status": "success",
        "startDate": "2026-04-20T18:00:09.639Z",
        "endDate": "2026-04-20T18:00:56.512Z",
        "duration": 9206
      },
      ...
    ]
  }