### PR TITLE
Add CI workflow for build and lint on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-and-lint:
+    name: Build and lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs on every pull request
- Triggers on PR open, reopen, and new commits pushed (`synchronize`)
- Runs `npm ci`, `npm run build`, and `npm run lint` across all packages in the monorepo