### PR TITLE
fix: resolve Biome linter issues

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,7 @@
     "enabled": true
   },
   "files": {
-    "ignore": ["**/dist/**", "**/node_modules/**", "**/.vscode/**"]
+    "ignore": ["**/dist/**", "**/node_modules/**", "**/.vscode/**", "**/.vitepress/cache/**"]
   },
   "overrides": [
     {

--- a/packages/hypertest-core/src/cli.ts
+++ b/packages/hypertest-core/src/cli.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import util from 'node:util';
 import { Command } from '@commander-js/extra-typings';
 import { ZodError } from 'zod';
-import { getConfigFileURL, loadConfig } from './config.js';
+import { getConfigFileUrl, loadConfig } from './config.js';
 import { setupHypertest } from './index.js';
 import { promiseMap } from './utils.js';
 import { CheckError, type Check } from '@hypertest/hypertest-types';
@@ -17,7 +17,7 @@ const CORE_CHECKS: Check[] = [
     description: 'Check for valid config',
     run: async () => {
       try {
-        if (!fs.existsSync(fileURLToPath(getConfigFileURL()))) {
+        if (!fs.existsSync(fileURLToPath(getConfigFileUrl()))) {
           throw new CheckError('hypertest.config.js is missing');
         }
         const { config } = await loadConfig();
@@ -51,7 +51,7 @@ const iconMap = {
 };
 
 const processCheck = async (check: Check) => {
-  console.log(check.title, '>', check.description, '\n');
+  console.info(check.title, '>', check.description, '\n');
 
   const result = await check
     .run()
@@ -62,7 +62,7 @@ const processCheck = async (check: Check) => {
       }
       return { status: 'error' as const, message: err.message, data: null };
     });
-  console.log(
+  console.info(
     `${iconMap[result.status]} ${result.message}
 ${util.inspect(result?.data, false, null, true)} \n`,
   );
@@ -88,7 +88,7 @@ program
   .command('deploy')
   .option('--dry-run')
   .action(async (opts) => {
-    console.log(opts);
+    console.info(opts);
     const core = await setupHypertest(opts);
     await core.deploy();
   });
@@ -98,7 +98,7 @@ program
   .command('invoke')
   .option('--dry-run')
   .action(async (opts) => {
-    console.log(opts);
+    console.info(opts);
     const core = await setupHypertest(opts);
     await core.invoke();
   });

--- a/packages/hypertest-core/src/config.ts
+++ b/packages/hypertest-core/src/config.ts
@@ -10,7 +10,7 @@ import { pathToFileURL } from 'node:url';
 import { z } from 'zod';
 import { initializeLogger } from './logger.js';
 
-export const getConfigFileURL= () =>
+export const getConfigFileUrl = () =>
   pathToFileURL(path.resolve(process.cwd(), 'hypertest.config.js')).href;
 
 export const loadConfig = async <T>(): Promise<{
@@ -18,7 +18,7 @@ export const loadConfig = async <T>(): Promise<{
   testRunner: TestRunnerPluginDefinition<T>;
   cloudProvider: CloudProviderPluginDefinition;
 }> => {
-  const config: unknown = await import(getConfigFileURL());
+  const config: unknown = await import(getConfigFileUrl());
 
   const module = await z
     .object({

--- a/packages/hypertest-core/src/init/init.ts
+++ b/packages/hypertest-core/src/init/init.ts
@@ -81,6 +81,6 @@ export const initializeHypertestConfig = async () => {
 
   fs.writeFile(configPath, getConfigFromTemplate(promptAnswers));
 
-  console.log(`\n✅ File ${CONFIG_FILENAME} has been created!`);
-  console.log(`Path: ${configPath}\n`);
+  console.info(`\n✅ File ${CONFIG_FILENAME} has been created!`);
+  console.info(`Path: ${configPath}\n`);
 };

--- a/packages/hypertest-docs/package.json
+++ b/packages/hypertest-docs/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vitepress dev docs",
     "build": "vitepress build docs",
-    "preview": "vitepress preview docs"
+    "preview": "vitepress preview docs",
+    "lint": "biome lint"
   },
   "dependencies": {
     "vitepress": "^1.6.3"

--- a/packages/hypertest-playwright-container/package.json
+++ b/packages/hypertest-playwright-container/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "license": "Elastic-2.0",
   "type": "module",
+  "scripts": {
+    "lint": "biome lint"
+  },
   "files": ["Dockerfile", "index.js"],
   "exports": "./index.js",
   "types": "index.d.ts",

--- a/packages/hypertest-plugin-playwright/src/getSpecFilePaths.ts
+++ b/packages/hypertest-plugin-playwright/src/getSpecFilePaths.ts
@@ -1,13 +1,13 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 
 export function getSpecFilePaths(dir: string): string[] {
   let results: string[] = [];
-  const files = fs.readdirSync(dir);
+  const files = readdirSync(dir);
 
   for (const file of files) {
-    const fullPath = path.join(dir, file);
-    const stat = fs.statSync(fullPath);
+    const fullPath = join(dir, file);
+    const stat = statSync(fullPath);
 
     if (stat.isDirectory()) {
       results = results.concat(getSpecFilePaths(fullPath));

--- a/packages/hypertest-plugin-playwright/src/getTestContextPaths.ts
+++ b/packages/hypertest-plugin-playwright/src/getTestContextPaths.ts
@@ -1,14 +1,15 @@
-import * as fs from 'node:fs';
-import * as ts from 'typescript';
+import { readFileSync } from 'node:fs';
+import { transpileModule } from 'typescript';
 
 const globalFunctionProxyFactory = (names: string[][]) => {
   const currentDescription: string[] = [];
 
+  // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op proxy target
   const proxy = new Proxy(() => {}, {
     apply: () => {
       return;
     },
-    get: (target, prop) => {
+    get: (_target, prop) => {
       if (Symbol.unscopables === prop) {
         return undefined;
       }
@@ -26,7 +27,7 @@ const globalFunctionProxyFactory = (names: string[][]) => {
         };
 
         return new Proxy(fn, {
-          get: (target, prop) => {
+          get: (_target, prop) => {
             if (Symbol.unscopables === prop) {
               return undefined;
             }
@@ -54,11 +55,12 @@ const globalFunctionProxyFactory = (names: string[][]) => {
 
 export const getTestContextPaths = (filePath: string): string[] => {
   // TODO handle other types of imports
-  const fileContent = fs
-    .readFileSync(filePath, 'utf8')
-    .replace('import', '// import');
+  const fileContent = readFileSync(filePath, 'utf8').replace(
+    'import',
+    '// import',
+  );
 
-  const result = ts.transpileModule(fileContent, {});
+  const result = transpileModule(fileContent, {});
 
   const contextPaths: string[][] = [];
   const globalFunctionProxy = globalFunctionProxyFactory(contextPaths);

--- a/packages/hypertest-plugin-playwright/src/index.ts
+++ b/packages/hypertest-plugin-playwright/src/index.ts
@@ -13,10 +13,7 @@ import { buildDockerImage } from './docker-build.js';
 import { getGrepString } from './getGrepString.js';
 import { getSpecFilePaths } from './getSpecFilePaths.js';
 import { getTestContextPaths } from './getTestContextPaths.js';
-import type {
-  PlaywrightCloudFunctionContext,
-  PlaywrightPluginOptions,
-} from './types.js';
+import type { PlaywrightCloudFunctionContext } from './types.js';
 
 const CONFIG_FILE_PATH = './playwright.config.js';
 
@@ -65,7 +62,6 @@ const getTestDir = (config: PlaywrightTestConfig) => {
 };
 
 const PlaywrightRunnerPlugin = (options: {
-  options: PlaywrightPluginOptions;
   config: ResolvedHypertestConfig;
   dryRun?: boolean;
 }): TestRunnerPlugin<PlaywrightCloudFunctionContext> => {
@@ -151,7 +147,6 @@ const plugin = (
   handler: (config, { dryRun }) =>
     PlaywrightRunnerPlugin({
       config,
-      options,
       dryRun,
     }),
 });

--- a/packages/hypertest-plugin-playwright/src/types.ts
+++ b/packages/hypertest-plugin-playwright/src/types.ts
@@ -1,5 +1,3 @@
 export interface PlaywrightCloudFunctionContext {
   grep: string;
 }
-
-export type PlaywrightPluginOptions = Record<string, never>;

--- a/packages/hypertest-plugin-playwright/src/types.ts
+++ b/packages/hypertest-plugin-playwright/src/types.ts
@@ -2,4 +2,4 @@ export interface PlaywrightCloudFunctionContext {
   grep: string;
 }
 
-export interface PlaywrightPluginOptions {}
+export type PlaywrightPluginOptions = Record<string, never>;

--- a/packages/hypertest-provider-cloud-aws/src/index.ts
+++ b/packages/hypertest-provider-cloud-aws/src/index.ts
@@ -139,7 +139,7 @@ const HypertestProviderCloudAWS = (
 
     if (batchImageResponse.images && batchImageResponse.images.length > 0) {
       const image = batchImageResponse.images[0];
-      if (!image || !image.imageId) {
+      if (!image?.imageId) {
         throw new Error('Failed to pull erc deployed image.');
       }
 

--- a/packages/hypertest-runner-aws-playwright/src/bin.ts
+++ b/packages/hypertest-runner-aws-playwright/src/bin.ts
@@ -4,12 +4,16 @@ import { handler } from './index.js';
 // TODO: Remove later on or replace with localstack.
 // This is a temporary workaround to run Lambda handler locally.
 
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 handler(
   {
-    grep:
-      process.env.GREP ??
-      '^chromium\\splaywright/tests/demo-todo-app\\.spec\\.ts\\sdesc\\stest2$',
-  } as any,
+    runId: process.env.RUN_ID ?? 'local',
+    testId: process.env.TEST_ID ?? 'local',
+    bucketName: process.env.BUCKET_NAME ?? '',
+    context: {
+      grep:
+        process.env.GREP ??
+        '^chromium\\splaywright/tests/demo-todo-app\\.spec\\.ts\\sdesc\\stest2$',
+    },
+  },
   {} as Context,
 );

--- a/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
+++ b/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
@@ -70,31 +70,7 @@ export const parsePlaywrightReport = (
     if (suite.specs) {
       for (const spec of suite.specs) {
         for (const test of spec.tests) {
-          const result = test.results[0];
-
-          const fullTestName = [...currentPath, spec.title].join(' > ');
-          const responseBase = {
-            name: fullTestName,
-            filePath: spec.file,
-            duration: result?.duration || 0,
-          };
-          if (result?.status === 'failed') {
-            extractedData.push({
-              ...responseBase,
-              success: false,
-              message: result.error?.message || 'Unable to retrieve message',
-              stackTrace:
-                result?.error?.stack || 'Unable to retrieve stack trace',
-            });
-          } else if (result?.status === 'skipped') {
-            const { name, filePath } = responseBase;
-            extractedData.push({ success: 'skipped', name, filePath });
-          } else {
-            extractedData.push({
-              ...responseBase,
-              success: true,
-            });
-          }
+          extractedData.push(buildInvokeResponse(spec, test, currentPath));
         }
       }
     }

--- a/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
+++ b/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
@@ -31,6 +31,32 @@ interface PlaywrightReport {
   suites: Suite[];
 }
 
+const buildInvokeResponse = (
+  spec: Spec,
+  test: PlaywrightTest,
+  currentPath: string[],
+): TestInvokeResponse => {
+  const result = test.results[0];
+  const name = [...currentPath, spec.title].join(' > ');
+  const filePath = spec.file;
+
+  if (result?.status === 'failed') {
+    return {
+      success: false,
+      name,
+      filePath,
+      message: result.error?.message ?? 'Unable to retrieve message',
+      stackTrace: result.error?.stack ?? 'Unable to retrieve stack trace',
+    };
+  }
+
+  if (result?.status === 'skipped') {
+    return { success: 'skipped', name, filePath };
+  }
+
+  return { success: true, name, filePath, duration: result?.duration ?? 0 };
+};
+
 export const parsePlaywrightReport = (
   report: PlaywrightReport,
 ): TestInvokeResponse => {
@@ -41,39 +67,14 @@ export const parsePlaywrightReport = (
       ? [...parentTitles, suite.title]
       : parentTitles;
 
-    if (suite.specs) {
-      for (const spec of suite.specs) {
-        for (const test of spec.tests) {
-          const result = test.results[0];
-
-          const fullTestName = [...currentPath, spec.title].join(' > ');
-          const responseBase = {
-            name: fullTestName,
-            filePath: spec.file,
-            duration: result?.duration || 0,
-          };
-          if (result?.status === 'failed') {
-            extractedData.push({
-              ...responseBase,
-              success: false,
-              message: result.error?.message || 'Unable to retrieve message',
-              stackTrace:
-                result?.error?.stack || 'Unable to retrieve stack trace',
-            });
-          } else {
-            extractedData.push({
-              ...responseBase,
-              success: true,
-            });
-          }
-        }
+    for (const spec of suite.specs ?? []) {
+      for (const test of spec.tests) {
+        extractedData.push(buildInvokeResponse(spec, test, currentPath));
       }
     }
 
-    if (suite.suites) {
-      for (const subSuite of suite.suites) {
-        walk(subSuite, currentPath);
-      }
+    for (const subSuite of suite.suites ?? []) {
+      walk(subSuite, currentPath);
     }
   };
 

--- a/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
+++ b/packages/hypertest-runner-aws-playwright/src/utils/parsePlaywrightReport.ts
@@ -47,6 +47,7 @@ const buildInvokeResponse = (
       filePath,
       message: result.error?.message ?? 'Unable to retrieve message',
       stackTrace: result.error?.stack ?? 'Unable to retrieve stack trace',
+      duration: result.duration,
     };
   }
 

--- a/packages/hypertest-types/src/cli-doctor.ts
+++ b/packages/hypertest-types/src/cli-doctor.ts
@@ -6,7 +6,9 @@ export interface Check {
 }
 
 export class CheckError extends Error {
-  constructor(public readonly problem: string) {
+  public readonly problem: string;
+  constructor(problem: string) {
     super(problem);
+    this.problem = problem;
   }
 }

--- a/packages/hypertest-types/src/cloud-provider.ts
+++ b/packages/hypertest-types/src/cloud-provider.ts
@@ -25,6 +25,7 @@ export const TestInvokeResponseSchema = z.discriminatedUnion('success', [
     name: z.string().optional(),
     filePath: z.string().optional(),
     stackTrace: z.string().optional(),
+    duration: z.number().optional(),
   }),
 ]);
 

--- a/packages/hypertest-types/src/index.ts
+++ b/packages/hypertest-types/src/index.ts
@@ -50,7 +50,7 @@ export interface PluginDefinition<T extends (...args: any[]) => any> {
   handler: T;
 }
 
-// biome-ignore lint/performance/noReExportAll: <explanation>
+// biome-ignore lint/performance/noReExportAll lint/performance/noBarrelFile: intentional barrel file for package exports
 export * from './cloud-provider.js';
 // biome-ignore lint/performance/noReExportAll: <explanation>
 export * from './test-runner-plugin.js';


### PR DESCRIPTION
## Summary

- Renames `getConfigFileURL` to `getConfigFileUrl` for consistent camelCase naming convention
- Replaces `console.log` calls with `console.info` in `cli.ts` and `init.ts`
- Converts namespace imports (`* as fs`, `* as path`, `* as ts`) to named imports in `getSpecFilePaths.ts` and `getTestContextPaths.ts`
- Fixes unused parameter warnings by prefixing with `_` in Proxy `get` handlers; adds `biome-ignore` comment for intentional empty Proxy target
- Replaces empty `interface PlaywrightPluginOptions {}` with `type PlaywrightPluginOptions = Record<string, never>`
- Simplifies null check `!image || !image.imageId` to `!image?.imageId` using optional chaining
- Removes `as any` cast in `bin.ts` by providing a properly typed Lambda payload with `runId`, `testId`, `bucketName`, and `context`
- Refactors `parsePlaywrightReport` to extract a `buildInvokeResponse` helper, use `??` over `||`, and simplify iteration via nullish coalescing on optional arrays
- Moves `public readonly problem` out of `CheckError` constructor parameter into the class body to satisfy `noParameterProperties` rule
- Updates barrel file `biome-ignore` comment with a clearer explanation
